### PR TITLE
FIX: Free `spanBytes` and `clusters`

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -1120,6 +1120,8 @@ void fiftyoneDegreesIpiGraphFree(fiftyoneDegreesIpiCgArray* graphs) {
 			&graphs->items[i].itemInfo);
 		FIFTYONE_DEGREES_COLLECTION_FREE(graphs->items[i].nodes);
 		FIFTYONE_DEGREES_COLLECTION_FREE(graphs->items[i].spans);
+		FIFTYONE_DEGREES_COLLECTION_FREE(graphs->items[i].spanBytes);
+		FIFTYONE_DEGREES_COLLECTION_FREE(graphs->items[i].clusters);
 	}
 	Free(graphs);
 }


### PR DESCRIPTION
Free collections that have been allocated.