### PR TITLE
Fixes for using with file collections

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -1062,7 +1062,7 @@ static IpiCgArray* ipiGraphCreate(
 		// Create the collection for the node values. Must overwrite the count
 		// to zero as it is consumed as a variable width collection.
 		CollectionHeader headerNodes = graphs->items[i].info.nodes.collection;
-		headerNodes.count = 0;
+		headerNodes.count = headerNodes.length;
 		graphs->items[i].nodes = collectionCreate(headerNodes, state);
 		if (graphs->items[i].nodes == NULL) {
 			EXCEPTION_SET(CORRUPT_DATA);

--- a/graph.c
+++ b/graph.c
@@ -497,7 +497,6 @@ static void setCluster(Cursor* cursor) {
 	// Use binary search to find the index for the cluster. The comparer
 	// records the last cluster checked the cursor will have the correct 
 	// cluster after the search operation.
-	Item cursorItem;
 	uint32_t index = setClusterSearch(
 		cursor->graph->clusters,
 		0,
@@ -1049,7 +1048,7 @@ static IpiCgArray* ipiGraphCreate(
 		DataReset(&itemInfo.data);
 
 		// Get the information from the collection provided.
-		graphs->items[i].info = *(IpiCgInfo*)collection->get(
+		const IpiCgInfo* const info = (IpiCgInfo*)collection->get(
 			collection, 
 			i,
 			&itemInfo,
@@ -1058,6 +1057,7 @@ static IpiCgArray* ipiGraphCreate(
 			fiftyoneDegreesIpiGraphFree(graphs);
 			return NULL;
 		}
+		graphs->items[i].info = *info;
 		COLLECTION_RELEASE(collection, &itemInfo);
 		graphs->count++;
 

--- a/graph.h
+++ b/graph.h
@@ -173,7 +173,6 @@ typedef struct fiftyone_degrees_ipi_cg_t {
 	fiftyoneDegreesCollection* clusters; /**< Clusters collection */
 	uint32_t spansCount; /**< Number of spans available */
 	uint32_t clustersCount; /**< Number of clusters available */
-	fiftyoneDegreesCollectionItem itemInfo; /**< Handle for info */
 } fiftyoneDegreesIpiCg;
 
 /**

--- a/graph.h
+++ b/graph.h
@@ -166,7 +166,7 @@ typedef struct fiftyone_degrees_ipi_cg_info_t {
  * component graph.
  */
 typedef struct fiftyone_degrees_ipi_cg_t {
-	fiftyoneDegreesIpiCgInfo* info;
+	fiftyoneDegreesIpiCgInfo info;
 	fiftyoneDegreesCollection* nodes; /**< Nodes collection */
 	fiftyoneDegreesCollection* spans; /**< Spans collection */
 	fiftyoneDegreesCollection* spanBytes; /**< Span bytes collection */


### PR DESCRIPTION
### Changes

- Remove `item: Item` from `struct cursor_t` (aka `Cursor`) -- in fear of misuse by reentrant functions.
- Make `info` in `IpiCg` no longer a pointer to `IpiCgInfo`, but a copy -- as the item (`info` was extracted from) wasn't being held onto for long enough.
- Modify `ipiGraphCreateFromFile` to behave like `ipiGraphCreateFromMemory` -- moving reader position before when reading the graph.