### PR TITLE
Improve `GET_BIT` / `extractValue`

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -644,12 +644,8 @@ static uint64_t extractValue(
 	unsigned bitIndex) {
 	uint64_t result = 0;
 	for (unsigned i = 0, s = bitIndex; i < recordSize; i++, s++) {
-		if (GET_BIT(source, s)) {
-			result = (result << 1) | 1;
-		}
-		else {
-			result = result << 1;
-		}
+		result <<= 1;
+		result |= GET_BIT(source, s);
 	}
 	return result;
 }

--- a/graph.c
+++ b/graph.c
@@ -124,7 +124,7 @@ typedef struct cursor_t {
 
 // Get the bit as a bool for the byte array and bit index from the left. High
 // order bit is index 0.
-#define GET_BIT(b,i) ((b[(i) / 8] & (1 << (7 - ((i) % 8)))) != 0)
+#define GET_BIT(b,i) ((((b)[(i) / 8] >> (7 - ((i) % 8))) & 1))
 
 // Sets the bit in the destination byte array where the bit index is from 
 // left. High order bit is index 0.


### PR DESCRIPTION
### Changes

- Replace `GET_BIT` with faster implementation
  - See benchmark below
- Remove conditionals ( `!=` / `?:` ) from `extractValue` loop body (to minimize prediction misses).

### Macro benchmark

[main.c.txt](https://github.com/user-attachments/files/20081427/main.c.txt)

Release / VS results (CLion):
```
Macro 1 Time: 7.476000 seconds
Macro 2 Time: 5.577000 seconds
Macro 1 Time: 7.364000 seconds
Macro 2 Time: 5.575000 seconds
Macro 1 Time: 7.382000 seconds
Macro 2 Time: 5.791000 seconds
Validation passed!
```
Release / MinGW results (CLion)
```
Macro 1 Time: 6.206000 seconds
Macro 2 Time: 5.386000 seconds
Macro 1 Time: 6.283000 seconds
Macro 2 Time: 5.396000 seconds
Macro 1 Time: 6.247000 seconds
Macro 2 Time: 5.364000 seconds
Validation passed!
```
Release-x64 (Visual Studio)
```
Macro 1 Time: 7.988000 seconds
Macro 2 Time: 5.889000 seconds
Macro 1 Time: 7.697000 seconds
Macro 2 Time: 5.909000 seconds
Macro 1 Time: 7.734000 seconds
Macro 2 Time: 5.918000 seconds
Validation passed!
```