### PR TITLE
performance improvement

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -1186,7 +1186,7 @@ fiftyoneDegreesIpiCgArray* fiftyoneDegreesIpiGraphCreateFromFile(
 }
 
 fiftyoneDegreesIpiCgResult fiftyoneDegreesIpiGraphEvaluate(
-	fiftyoneDegreesIpiCgArray* const graphs,
+    const fiftyoneDegreesIpiCgArray*  const graphs,
 	const byte componentId,
 	const fiftyoneDegreesIpAddress address,
 	fiftyoneDegreesException* const exception) {

--- a/graph.h
+++ b/graph.h
@@ -252,7 +252,7 @@ EXTERNAL fiftyoneDegreesIpiCgArray* fiftyoneDegreesIpiGraphCreateFromFile(
  * @return the index of the profile (or group) associated with the IP address.
  */
 EXTERNAL fiftyoneDegreesIpiCgResult fiftyoneDegreesIpiGraphEvaluate(
-	fiftyoneDegreesIpiCgArray* graphs,
+	const fiftyoneDegreesIpiCgArray* graphs,
 	byte componentId,
 	fiftyoneDegreesIpAddress address,
 	fiftyoneDegreesException* exception);


### PR DESCRIPTION
@drasmart's alternative implementation of the #24 

- uses a clever ownership hack, this way we don't have to do `memcpy` at all, as ownership to the already loaded item memory is moved to the `clusterWrapper` in the `setClusterComparer`.  due to swap the previously loaded items are freed in the next iteration of the binary search loop, the last one stays and freed in `cursorRelease`.

- also bitwise operations are optimized in `extracValue`