### PR TITLE
Introduce `CollectionKey` struct

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -1222,9 +1222,16 @@ static IpiCgArray* ipiGraphCreate(
 			graphs->items[i].spans);
 
 		// Create the collection for the span bytes.
-		graphs->items[i].spanBytes = collectionCreate(
-			graphs->items[i].info.spanBytes,
-			state);
+		{
+			const CollectionHeader spanBytesHeader = {
+				graphs->items[i].info.spanBytes.startPosition,
+				graphs->items[i].info.spanBytes.length,
+				graphs->items[i].info.spanBytes.length,
+			};
+			graphs->items[i].spanBytes = collectionCreate(
+				spanBytesHeader,
+				state);
+		}
 		if (graphs->items[i].spanBytes == NULL) {
 			EXCEPTION_SET(CORRUPT_DATA);
 			fiftyoneDegreesIpiGraphFree(graphs);

--- a/graph.c
+++ b/graph.c
@@ -480,7 +480,7 @@ static uint32_t setClusterSearch(
 			middle,
 			&keyType,
 		};
-		if (collection->get(collection, key, &item, exception) == NULL ||
+		if (collection->get(collection, &key, &item, exception) == NULL ||
 			EXCEPTION_OKAY == false) {
 			return 0;
 		}
@@ -590,7 +590,7 @@ static void setSpanBytes(Cursor* cursor) {
 	};
 	byte* bytes = cursor->graph->spanBytes->get(
 		cursor->graph->spanBytes,
-		spanBytesKey,
+		&spanBytesKey,
 		&cursorItem,
 		cursor->ex);
 	if (EXCEPTION_FAILED) return;
@@ -674,7 +674,7 @@ static void setSpan(Cursor* cursor) {
 	};
 	cursor->span = *(Span*)cursor->graph->spans->get(
 		cursor->graph->spans,
-		spanKey,
+		&spanKey,
 		&cursorItem,
 		exception);
 	if (EXCEPTION_FAILED) return;
@@ -774,7 +774,7 @@ static void cursorMove(Cursor* const cursor, const uint32_t index) {
 	};
 	const byte* const ptr = (byte*)cursor->graph->nodes->get(
 		cursor->graph->nodes,
-		nodeBytesKey,
+		&nodeBytesKey,
 		&cursorItem,
 		exception);
 	if (EXCEPTION_FAILED) return;
@@ -1197,7 +1197,7 @@ static IpiCgArray* ipiGraphCreate(
 		};
 		const IpiCgInfo* const info = (IpiCgInfo*)collection->get(
 			collection, 
-			infoKey,
+			&infoKey,
 			&itemInfo,
 			exception);
 		if (EXCEPTION_FAILED) {

--- a/graph.c
+++ b/graph.c
@@ -454,7 +454,7 @@ static int setClusterComparer(
 }
 
 static uint32_t setClusterSearch(
-	fiftyoneDegreesCollection* const collection,
+	const fiftyoneDegreesCollection* const collection,
 	const uint32_t lowerIndex,
 	const uint32_t upperIndex,
 	Cursor* const cursor,
@@ -462,9 +462,9 @@ static uint32_t setClusterSearch(
 	uint32_t upper = upperIndex,
 		lower = lowerIndex,
 		middle = 0;
-	CollectionKeyType keyType = {
+	const CollectionKeyType keyType = {
 		FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_CLUSTER,
-		0, // TBD
+		collection->elementSize, // TBD
 		NULL,
 	};
 	while (lower <= upper) {
@@ -475,7 +475,6 @@ static uint32_t setClusterSearch(
 		middle = lower + (upper - lower) / 2;
 
 		// Get the item from the collection checking for NULL or an error.
-		keyType.initialBytesCount = collection->elementSize;
 		const CollectionKey key = {
 			middle,
 			&keyType,

--- a/graph.c
+++ b/graph.c
@@ -464,7 +464,7 @@ static uint32_t setClusterSearch(
 		middle = 0;
 	const CollectionKeyType keyType = {
 		FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_CLUSTER,
-		collection->elementSize, // TBD
+		collection->elementSize,
 		NULL,
 	};
 	while (lower <= upper) {

--- a/graph.c
+++ b/graph.c
@@ -671,12 +671,13 @@ static void setSpan(Cursor* cursor) {
 		spanIndex,
 		&CollectionKeyType_Span,
 	};
-	cursor->span = *(Span*)cursor->graph->spans->get(
+	Span * const span = (Span*)cursor->graph->spans->get(
 		cursor->graph->spans,
 		&spanKey,
 		&cursorItem,
 		exception);
-	if (EXCEPTION_FAILED) return;
+	if (!span || EXCEPTION_FAILED) return;
+	cursor->span = *span;
 	COLLECTION_RELEASE(cursor->graph->spans, &cursorItem);
 
 	// Ensure set to 0s before the bits are copied.

--- a/graph.c
+++ b/graph.c
@@ -469,13 +469,14 @@ static uint32_t setClusterSearch(
 		middle = lower + (upper - lower) / 2;
 
 		// Get the item from the collection checking for NULL or an error.
+		const CollectionKeyType keyType = {
+			FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_CLUSTER,
+			collection->elementSize,
+			NULL,
+		};
 		const CollectionKey key = {
 			middle,
-			{
-				FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_CLUSTER,
-				collection->elementSize,
-				NULL,
-			},
+			&keyType,
 		};
 		if (collection->get(collection, key, &item, exception) == NULL ||
 			EXCEPTION_OKAY == false) {
@@ -576,13 +577,14 @@ static void setSpanBytes(Cursor* cursor) {
 	DataReset(&cursorItem.data);
 	const uint32_t totalBits = cursor->span.lengthLow + cursor->span.lengthHigh;
 	const uint32_t totalBytes = (totalBits / 8) + ((totalBits % 8) ? 1 : 0);
+	const CollectionKeyType keyType = {
+		FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_SPAN_BYTES,
+		totalBytes,
+		NULL,
+	};
 	const CollectionKey spanBytesKey = {
 		cursor->span.trail.offset,
-		{
-			FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_SPAN_BYTES,
-			totalBytes,
-			NULL,
-		},
+		&keyType,
 	};
 	byte* bytes = cursor->graph->spanBytes->get(
 		cursor->graph->spanBytes,
@@ -666,7 +668,7 @@ static void setSpan(Cursor* cursor) {
 	DataReset(&cursorItem.data);
 	const CollectionKey spanKey = {
 		spanIndex,
-		CollectionKeyType_Span,
+		&CollectionKeyType_Span,
 	};
 	cursor->span = *(Span*)cursor->graph->spans->get(
 		cursor->graph->spans,
@@ -762,13 +764,14 @@ static void cursorMove(Cursor* const cursor, const uint32_t index) {
 	DataReset(&cursorItem.data);
 	const uint32_t totalBits = cursor->graph->info.nodes.recordSize + bitIndex;
 	const uint32_t totalBytes = (totalBits / 8) + ((totalBits % 8) ? 1 : 0);
+	const CollectionKeyType keyType = {
+		FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_NODE_BYTES,
+		totalBytes,
+		NULL,
+	};
 	const CollectionKey nodeBytesKey = {
 		(uint32_t)byteIndex,
-		{
-			FIFTYONE_DEGREES_COLLECTION_ENTRY_TYPE_GRAPH_DATA_NODE_BYTES,
-			totalBytes,
-			NULL,
-		},
+		&keyType,
 	};
 	const byte* const ptr = (byte*)cursor->graph->nodes->get(
 		cursor->graph->nodes,
@@ -1183,7 +1186,7 @@ static IpiCgArray* ipiGraphCreate(
 		// Get the information from the collection provided.
 		const CollectionKey infoKey = {
 			i,
-			CollectionKeyType_GraphInfo,
+			&CollectionKeyType_GraphInfo,
 		};
 		const IpiCgInfo* const info = (IpiCgInfo*)collection->get(
 			collection, 

--- a/graph.c
+++ b/graph.c
@@ -726,7 +726,7 @@ static uint64_t extractValue(
 		result = extractSubValue(
 			*source,
 			bitIndex,
-			(bitsAvailable < recordSize) ? bitsAvailable : recordSize);
+			(bitsAvailable < recordSize) ? bitsAvailable : (uint8_t)recordSize);
 	}
 	int remainingBits = recordSize + bitIndex - 8;
 
@@ -738,7 +738,7 @@ static uint64_t extractValue(
 
 	if (remainingBits > 0) {
 		result <<= remainingBits;
-		result |= extractSubValue(*nextByte, 0, remainingBits);
+		result |= extractSubValue(*nextByte, 0, (uint8_t)remainingBits);
 	}
 
 	return result;

--- a/graph.c
+++ b/graph.c
@@ -433,8 +433,8 @@ static bool isExhausted(const Cursor* const cursor) {
 // Comparer used to determine if the selected cluster is higher or lower than
 // the target.
 static int setClusterComparer(
-	Cursor* cursor,
-	Item* item) {
+	Cursor* const cursor,
+	Item* const item) {
 	// Swap the ownership, so that Cursor now owns this item
 	{
 		const Item t = cursor->cluster.item;
@@ -445,12 +445,14 @@ static int setClusterComparer(
 
 	// If this cluster is within the require range then its the correct one
 	// to return.
-	if (cursor->index >= cursor->cluster.ptr->startIndex &&
-		cursor->index <= cursor->cluster.ptr->endIndex) {
+	const uint32_t searchIndex = cursor->index;
+	const uint32_t startIndex = cursor->cluster.ptr->startIndex;
+	if (searchIndex >= startIndex &&
+		searchIndex <= cursor->cluster.ptr->endIndex) {
 		return 0;
 	}
 
-	return cursor->cluster.ptr->startIndex - cursor->index;
+	return (startIndex > searchIndex) ? 1 : (startIndex < searchIndex) ? -1 : 0;
 }
 
 static uint32_t setClusterSearch(

--- a/graph.c
+++ b/graph.c
@@ -467,7 +467,8 @@ static uint32_t setClusterSearch(
 		middle = lower + (upper - lower) / 2;
 
 		// Get the item from the collection checking for NULL or an error.
-		if (collection->get(collection, middle, &item, exception) == NULL ||
+		const CollectionKey key = { middle };
+		if (collection->get(collection, key, &item, exception) == NULL ||
 			EXCEPTION_OKAY == false) {
 			return 0;
 		}
@@ -564,9 +565,10 @@ static void setSpanBytes(Cursor* cursor) {
 	// Use the current span offset to get the bytes.
 	Item cursorItem;
 	DataReset(&cursorItem.data);
+	const CollectionKey spanKey = { cursor->span.trail.offset };
 	byte* bytes = cursor->graph->spanBytes->get(
 		cursor->graph->spanBytes,
-		cursor->span.trail.offset,
+		spanKey,
 		&cursorItem,
 		cursor->ex);
 	if (EXCEPTION_FAILED) return;
@@ -638,9 +640,10 @@ static void setSpan(Cursor* cursor) {
 	// Set the span for the current span index.
 	Item cursorItem;
 	DataReset(&cursorItem.data);
+	const CollectionKey spanKey = { spanIndex };
 	cursor->span = *(Span*)cursor->graph->spans->get(
 		cursor->graph->spans,
-		spanIndex,
+		spanKey,
 		&cursorItem,
 		exception);
 	if (EXCEPTION_FAILED) return;
@@ -730,9 +733,10 @@ static void cursorMove(Cursor* const cursor, const uint32_t index) {
 	// Get a pointer to that byte from the collection.
 	Item cursorItem;
 	DataReset(&cursorItem.data);
+	const CollectionKey byteKey = { (uint32_t)byteIndex };
 	const byte* const ptr = (byte*)cursor->graph->nodes->get(
 		cursor->graph->nodes,
-		(uint32_t)byteIndex,
+		byteKey,
 		&cursorItem,
 		exception);
 	if (EXCEPTION_FAILED) return;
@@ -1135,9 +1139,10 @@ static IpiCgArray* ipiGraphCreate(
 		DataReset(&itemInfo.data);
 
 		// Get the information from the collection provided.
+		const CollectionKey infoKey = { i };
 		const IpiCgInfo* const info = (IpiCgInfo*)collection->get(
 			collection, 
-			i,
+			infoKey,
 			&itemInfo,
 			exception);
 		if (EXCEPTION_FAILED) {


### PR DESCRIPTION
### Changes

#### ⬇️ Compilation fixes for compatibility with https://github.com/51Degrees/common-cxx/pull/117 / https://github.com/51Degrees/common-cxx/pull/120 .

- Add `nodeBytesKeyType: CollectionKeyType` to `Cursor`
  - to be reused (with modified `initialBytesCount`) when requesting node bytes (instead of rebuilding the whole struct).
- Use `CollectionKey` to access elements.
- Check `spans->get` result before dereferencing.
- Use unsigned comparison to prevent `int` overflow.
- Add exception checks to more places.

### Why

- https://github.com/51Degrees/ip-intelligence-cxx/issues/21