### PR TITLE
FIX: implicit `uint8_t` casts.

### DIFF
--- a/graph.c
+++ b/graph.c
@@ -696,7 +696,7 @@ static uint64_t extractValue(
 		result = extractSubValue(
 			*source,
 			bitIndex,
-			(bitsAvailable < recordSize) ? bitsAvailable : recordSize);
+			(bitsAvailable < recordSize) ? bitsAvailable : (uint8_t)recordSize);
 	}
 	int remainingBits = recordSize + bitIndex - 8;
 
@@ -708,7 +708,7 @@ static uint64_t extractValue(
 
 	if (remainingBits > 0) {
 		result <<= remainingBits;
-		result |= extractSubValue(*nextByte, 0, remainingBits);
+		result |= extractSubValue(*nextByte, 0, (uint8_t)remainingBits);
 	}
 
 	return result;


### PR DESCRIPTION
Test run:
- https://github.com/51Degrees/ip-graph-cxx/actions/runs/15778205085/job/44477352673