### PR TITLE
Add UTM link lint workflow

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .


### PR DESCRIPTION
## Summary
This repository contains no navigational 51degrees.com links to tag (the README is a two-line stub and the source files only mention "51Degrees" as a company name in prose comments, with no URLs). So there is no UTM link commit.

To keep the repository covered by the shared tagging convention going forward, this PR adds the UTM link lint workflow only.

## What changed
- Added .github/workflows/utm-link-lint.yml, which runs the shared 51Degrees/common-ci UTM link linter on pull requests, pushes to main, and manual dispatch.

## Verification
- utm-lint.ps1 runs clean for campaign ip-graph-cxx (no links present, nothing to violate).